### PR TITLE
Respond with 200 to webhook creation HEAD request

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -76,6 +76,11 @@ function verifyTrelloWebhookRequest(request, secret) {
 
 // handles webhooks triggered by the Budget list in Trello
 exports.transaction = functions.https.onRequest((request, response) => {
+    // HEAD request on webhook creation only (https://developers.trello.com/page/webhooks)
+    if (request.method === 'HEAD') {
+        return response.status(200).end();
+    }
+    
     // validate request body
     if (!('body' in request) || !('action' in request.body) || !('type' in request.body.action)) {
         console.warn("Invalid Trello webhook request.");


### PR DESCRIPTION
From https://developers.trello.com/page/webhooks -
```The provided callbackURL must be a valid URL during the creation of the webhook. We run a quick HTTP HEAD request on the URL, and if a 200 status code is not returned in the response, then the webhook will not be created. ```